### PR TITLE
php7 fix - calling methods with curly braces

### DIFF
--- a/src/BirknerAlex/XMPPHP/XMLStream.php
+++ b/src/BirknerAlex/XMPPHP/XMLStream.php
@@ -648,7 +648,7 @@ class XMLStream {
 						if ($searchxml !== null) {
 							if($handler[2] === null) $handler[2] = $this;
 							$this->log->log("Calling {$handler[1]}",  Log::LEVEL_DEBUG);
-							$handler[2]->$handler[1]($this->xmlobj[2]);
+							$handler[2]->{$handler[1]}($this->xmlobj[2]);
 						}
 					}
 				}
@@ -662,13 +662,13 @@ class XMLStream {
 				if($searchxml !== null and $searchxml->name == $handler[0] and ($searchxml->ns == $handler[1] or (!$handler[1] and $searchxml->ns == $this->default_ns))) {
 					if($handler[3] === null) $handler[3] = $this;
 					$this->log->log("Calling {$handler[2]}",  Log::LEVEL_DEBUG);
-					$handler[3]->$handler[2]($this->xmlobj[2]);
+					$handler[3]->{$handler[2]}($this->xmlobj[2]);
 				}
 			}
 			foreach($this->idhandlers as $id => $handler) {
 				if(array_key_exists('id', $this->xmlobj[2]->attrs) and $this->xmlobj[2]->attrs['id'] == $id) {
 					if($handler[1] === null) $handler[1] = $this;
-					$handler[1]->$handler[0]($this->xmlobj[2]);
+					$handler[1]->{$handler[0]}($this->xmlobj[2]);
 					#id handlers are only used once
 					unset($this->idhandlers[$id]);
 					break;
@@ -724,7 +724,7 @@ class XMLStream {
 				if($handler[2] === null) {
 					$handler[2] = $this;
 				}
-				$handler[2]->$handler[1]($payload);
+				$handler[2]->{$handler[1]}($payload);
 			}
 		}
 


### PR DESCRIPTION
> Indirect access to variables, properties, and methods will now be evaluated strictly in left-to-right order, as opposed to the previous mix of special cases. The table below shows how the order of evaluation has changed.

> Code that used the old right-to-left evaluation order must be rewritten to explicitly use that evaluation order with curly braces (see the above middle column). **This will make the code both forwards compatible with PHP 7.x and backwards compatible with PHP 5.x.**

https://secure.php.net/manual/en/migration70.incompatible.php