### PR TITLE
Fix "string as array usage" errors on PHP 7

### DIFF
--- a/src/BirknerAlex/XMPPHP/XMLStream.php
+++ b/src/BirknerAlex/XMPPHP/XMLStream.php
@@ -119,13 +119,13 @@ class XMLStream {
 	 */
 	protected $default_ns;
 	/**
-	 * @var string
+	 * @var string[]
 	 */
-	protected $until = '';
+	protected $until = array();
 	/**
-	 * @var string
+	 * @var int[]
 	 */
-	protected $until_count = '';
+	protected $until_count = array();
 	/**
 	 * @var array
 	 */


### PR DESCRIPTION
Trying to call `processUntil()` method on PHP 7 ends up with following errors:

```
notifier-app  | Fatal error: Uncaught Error: [] operator not supported for strings in /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php:536
notifier-app  | Stack trace:
notifier-app  | #0 /app/notifier.php(139): BirknerAlex\XMPPHP\XMLStream->processUntil(Array)
notifier-app  | #1 /app/notifier.php(46): connectXMPP('notifier')
notifier-app  | #2 {main}
notifier-app  |   thrown in /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php on line 536

notifier-app  | [22-Sep-2017 13:18:18 Etc/UTC] PHP Fatal error:  Uncaught Error: Cannot use assign-op operators with string offsets in /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php:738
notifier-app  | Stack trace:
notifier-app  | #0 /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMPP.php(390): BirknerAlex\XMPPHP\XMLStream->event('session_start')
notifier-app  | #1 /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php(671): BirknerAlex\XMPPHP\XMPP->session_start_handler(Object(BirknerAlex\XMPPHP\XMLObj))
notifier-app  | #2 [internal function]: BirknerAlex\XMPPHP\XMLStream->endXML(Resource id #17, 'IQ')
notifier-app  | #3 /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php(477): xml_parse(Resource id #17, '<iq type='resul...', false)
notifier-app  | #4 /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php(550): BirknerAlex\XMPPHP\XMLStream->__process(NULL, true)
notifier-app  | #5 /app/notifier.php(139): BirknerAlex\XMPPHP\XMLStream->processUntil(Array)
notifier-app  | #6 /app/notifier.php(46): connectXMPP('notifier')
notifier-app  | #7 {main}
notifier-app  |   thrown in /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php on line 738

notifier-app  | Fatal error: Uncaught Error: Cannot use assign-op operators with string offsets in /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php:738
notifier-app  | Stack trace:
notifier-app  | #0 /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMPP.php(390): BirknerAlex\XMPPHP\XMLStream->event('session_start')
notifier-app  | #1 /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php(671): BirknerAlex\XMPPHP\XMPP->session_start_handler(Object(BirknerAlex\XMPPHP\XMLObj))
notifier-app  | #2 [internal function]: BirknerAlex\XMPPHP\XMLStream->endXML(Resource id #17, 'IQ')
notifier-app  | #3 /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php(477): xml_parse(Resource id #17, '<iq type='resul...', false)
notifier-app  | #4 /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php(550): BirknerAlex\XMPPHP\XMLStream->__process(NULL, true)
notifier-app  | #5 /app/notifier.php(139): BirknerAlex\XMPPHP\XMLStream->processUntil(Array)
notifier-app  | #6 /app/notifier.php(46): connectXMPP('notifier')
notifier-app  | #7 {main}
notifier-app  |   thrown in /app/vendor/tyrola/xmpphp/src/BirknerAlex/XMPPHP/XMLStream.php on line 738
```

I looked through the code and it seems that `XMLStream->until` and `XMLStream->until_count` are not used as `string` anywhere, but by default are declared as ones.  
So, simple change of default values in this PR does the work.