### PR TITLE
Set 'server' option when initializing XMPP object

### DIFF
--- a/src/BirknerAlex/XMPPHP/XMPP.php
+++ b/src/BirknerAlex/XMPPHP/XMPP.php
@@ -117,6 +117,7 @@ class XMPP extends XMLStream {
 		$this->password = $password;
 		$this->resource = $resource;
 		if(!$server) $server = $host;
+		$this->server = $server;
 		$this->basejid = $this->user . '@' . $this->host;
 
 		$this->roster = new Roster();


### PR DESCRIPTION
The option `server` exists in `XMPP` class, however is not set during initialization.

It's not used inside `XMPP` class at the moment, but makes a lot of confusion when extending it.