### PR TITLE
Do not finish socket reads until EOF is received

### DIFF
--- a/src/BirknerAlex/XMPPHP/XMLStream.php
+++ b/src/BirknerAlex/XMPPHP/XMLStream.php
@@ -461,7 +461,7 @@ class XMLStream {
 					$part = fread($this->socket, 4096);
 					stream_set_blocking($this->socket, 1);
 
-					if (!$part) {
+					if (!$part && feof($this->socket)) {
 						if($this->reconnect) {
 							$this->doReconnect();
 						} else {


### PR DESCRIPTION
This one was really painful...


## Synopsis

Sometimes there is a need to read a quite big amount of data from XMPP server (in my case it was a list of all online users). Such read cannot be performed in a single `fread($this->socket, 4096)` call. Therefore there is a [cycle](https://github.com/BirknerAlex/XMPPHP/blob/v2.1/src/BirknerAlex/XMPPHP/XMLStream.php#L454-L475) which does the job until all data is read. However, the [condition](https://github.com/BirknerAlex/XMPPHP/blob/v2.1/src/BirknerAlex/XMPPHP/XMLStream.php#L464) to determine data is over is implemented incorrectly. It will evaluate to `true` either `false` is returned by `fread()` or empty string `''`.

This leads to situations when `fread()` is tried to be performed on a socket when data hasn't been arrived yet (so empty string is returned), but also neither `EOF` is received, nor socket is closed, and so finishes everything in the middle.


## Solution

To correctly detect all the data is arrived we need to use [`feof()`](https://secure.php.net/manual/en/function.feof.php) as official documentation [recommends](https://secure.php.net/manual/en/function.fread.php#example-2891).