### PR TITLE
Add PHP extensions requirements to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,18 +5,21 @@
     "keywords": ["jabber", "xmpphp", "xmpp"],
     "homepage": "https://github.com/BirknerAlex/XMPPHP",
     "license": "GPL-2.0+",
-    "authors": [
-        {
-            "name": "Nathan Fritz",
-            "email": "fritzy@netflint.net",
-            "name": "bandroidx",
-            "email": "bandroidx@gmail.com",
-            "name": "BirknerAlex",
-            "email": "alex.birkner@gmail.com"
-        }
-    ],
+    "authors": [{
+        "name": "Nathan Fritz",
+        "email": "fritzy@netflint.net"
+    }, {
+        "name": "bandroidx",
+        "email": "bandroidx@gmail.com"
+    }, {
+        "name": "BirknerAlex",
+        "email": "alex.birkner@gmail.com"
+    }],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "ext-pcre": "*",
+        "ext-simplexml": "*",
+        "ext-xml": "*"
     },
     "autoload": {
         "psr-0": {

--- a/src/BirknerAlex/XMPPHP/Roster.php
+++ b/src/BirknerAlex/XMPPHP/Roster.php
@@ -165,4 +165,3 @@ class Roster {
 		return $this->roster_array;
 	}
 }
-?>


### PR DESCRIPTION
This PR adds used PHP extensions to the `require` section of `composer.json`.

## Motivation

We have many Docker-based PHP projects. Every projects requires its own set of PHP extensions. Having PHP extensions declared in `composer.json` allows us to avoid failures in runtime when some PHP extension is missing, by simply running test like `composer check-platform-reqs` inside Docker image.